### PR TITLE
Linewrap, XDG Confg Home & Refactoring

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -117,7 +117,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let dir_mngr_handle = tokio::spawn(dir_manager.run());
     let prev_mngr_handle = tokio::spawn(preview_manager.run());
 
-    // Read config file
+    // Read keybinding config
     let config_dir = xdg_config_home()?.join("rfm");
     let key_config_file = config_dir.join("keys.toml");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use crossterm::{
         disable_raw_mode, enable_raw_mode, Clear, ClearType, DisableLineWrap, EnterAlternateScreen,
         LeaveAlternateScreen,
     },
-    QueueableCommand, Result,
+    QueueableCommand,
 };
 use log::{info, warn};
 use logger::LogBuffer;
@@ -17,12 +17,14 @@ use notify_rust::Notification;
 use opener::OpenEngine;
 use panel::manager::PanelManager;
 use std::{
+    error::Error,
     fs::OpenOptions,
     io::{stdout, Write},
     path::PathBuf,
 };
 use symbols::SymbolEngine;
 use tokio::sync::mpsc;
+use util::xdg_config_home;
 
 mod commands;
 mod content;
@@ -42,7 +44,7 @@ struct Args {
 }
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn Error>> {
     let args = Args::parse();
 
     std::panic::set_hook(Box::new(|panic_info| {
@@ -118,8 +120,7 @@ async fn main() -> Result<()> {
     let prev_mngr_handle = tokio::spawn(preview_manager.run());
 
     // Read config file
-    let home = PathBuf::from(std::env::var("HOME").unwrap_or_default());
-    let config_dir = home.join(".config/rfm/");
+    let config_dir = xdg_config_home()?.join("rfm");
     let key_config_file = config_dir.join("keys.toml");
 
     let parser: CommandParser;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,8 +6,8 @@ use crossterm::{
     cursor,
     event::DisableMouseCapture,
     terminal::{
-        disable_raw_mode, enable_raw_mode, Clear, ClearType, DisableLineWrap, EnterAlternateScreen,
-        LeaveAlternateScreen,
+        disable_raw_mode, enable_raw_mode, Clear, ClearType, DisableLineWrap, EnableLineWrap,
+        EnterAlternateScreen, LeaveAlternateScreen,
     },
     QueueableCommand,
 };
@@ -182,6 +182,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     // Be a good citizen, cleanup
     stdout
+        .queue(EnableLineWrap)?
         .queue(Clear(ClearType::Purge))?
         .queue(LeaveAlternateScreen)?
         .queue(cursor::RestorePosition)?

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,22 +48,20 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let args = Args::parse();
 
     std::panic::set_hook(Box::new(|panic_info| {
-        let body;
-        let summary;
-        if let Some(s) = panic_info.payload().downcast_ref::<&str>() {
-            body = format!("panic occurred: {s:?}");
+        let body = if let Some(s) = panic_info.payload().downcast_ref::<&str>() {
+            format!("panic occurred: {s:?}")
         } else {
-            body = "panic occurred".to_string();
-        }
-        if let Some(location) = panic_info.location() {
-            summary = format!(
+            "panic occurred".to_string()
+        };
+        let summary = if let Some(location) = panic_info.location() {
+            format!(
                 "panic occurred in file '{}' at line {}",
                 location.file(),
                 location.line(),
-            );
+            )
         } else {
-            summary = "panic occurred somewhere".to_string();
-        }
+            "panic occurred somewhere".to_string()
+        };
         if Notification::new()
             .summary(&summary)
             .body(&body)
@@ -123,16 +121,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let config_dir = xdg_config_home()?.join("rfm");
     let key_config_file = config_dir.join("keys.toml");
 
-    let parser: CommandParser;
-    if let Ok(content) = std::fs::read_to_string(&key_config_file) {
+    let parser = if let Ok(content) = std::fs::read_to_string(&key_config_file) {
         match toml::from_str(&content) {
             Ok(key_config) => {
                 info!("Using keyboard config: {}", key_config_file.display());
-                parser = CommandParser::from_config(key_config);
+                CommandParser::from_config(key_config)
             }
             Err(e) => {
                 warn!("Configuration error: {e}. Using default keyboard bindings");
-                parser = CommandParser::default_bindings();
+                CommandParser::default_bindings()
             }
         }
     } else {
@@ -140,28 +137,27 @@ async fn main() -> Result<(), Box<dyn Error>> {
             "Cannot find keyboard config '{}'. Using default keyboard bindings",
             key_config_file.display()
         );
-        parser = CommandParser::default_bindings();
-    }
+        CommandParser::default_bindings()
+    };
 
     // Read opener config
     let open_config_file = config_dir.join("open.toml");
 
-    let opener: OpenEngine;
-    if let Ok(content) = std::fs::read_to_string(&open_config_file) {
+    let opener = if let Ok(content) = std::fs::read_to_string(&open_config_file) {
         match toml::from_str(&content) {
             Ok(open_config) => {
                 info!("Using open-engine config: {}", open_config_file.display());
-                opener = OpenEngine::with_config(open_config);
+                OpenEngine::with_config(open_config)
             }
             Err(e) => {
                 warn!("Configuration error: {e}. Using default open engine");
-                opener = OpenEngine::default();
+                OpenEngine::default()
             }
         }
     } else {
         info!("Using default open engine");
-        opener = OpenEngine::default();
-    }
+        OpenEngine::default()
+    };
 
     let panel_manager = PanelManager::new(
         parser,

--- a/src/util.rs
+++ b/src/util.rs
@@ -114,3 +114,17 @@ where
     }
     Ok(())
 }
+
+/// Query the XDG Config Home (usually ~/.config) according to
+/// https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+pub fn xdg_config_home() -> Result<PathBuf, Box<dyn Error>> {
+    match std::env::var("XDG_CONFIG_HOME") {
+        Ok(xdg_config) => Ok(PathBuf::from(xdg_config)),
+        Err(_) => match std::env::var("HOME") {
+            Ok(home) => Ok(PathBuf::from(home).join(".config")),
+            Err(_) => Err(format!(
+                "Neither the XDG_CONFIG_HOME nor the HOME environment variable was set."
+            ))?,
+        },
+    }
+}


### PR DESCRIPTION
This pull request consists of 3 changes:

1. Fixed a bug, where exiting rfm caused the terminal to misbehave (linewrap stayed disabled);
2. XDG Config Home is respected instead of always using `~/.config/rfm`; and
3. a few small code refactorings in `main.rs`.