### PR TITLE
Redraw the center panel after something has been copied

### DIFF
--- a/src/panel/manager.rs
+++ b/src/panel/manager.rs
@@ -999,6 +999,7 @@ impl PanelManager {
                             let files = self.marked_or_selected();
                             info!("copying {} items", files.len());
                             self.clipboard = Some(Clipboard { files, cut: false });
+                            self.redraw_center();
                         }
                         Command::Delete => {
                             let files = self.marked_or_selected();


### PR DESCRIPTION
When yanking a marked or selected item/s, the panel wasn't redrawn, leaving the selected entry/entries not highlighted until something else triggered a redraw.